### PR TITLE
Add posts.html to root of project

### DIFF
--- a/posts.html
+++ b/posts.html
@@ -1,0 +1,19 @@
+---
+layout: page
+---
+
+{% for tag in site.tags %}
+  {% assign t = tag | first %}
+  {% assign posts = tag | last %}
+
+<h2 class="category-key" id="{{ t | downcase }}">{{ t | capitalize }}</h2>
+
+<ul class="year">
+  {% for post in posts %}
+    {% if post.tags contains t %}
+      <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+    {% endif %}
+  {% endfor %}
+</ul>
+
+{% endfor %}


### PR DESCRIPTION
When posts in the _posts folder are generated, the left hand sidebar generated by
_includes/aside.html creates a reference to ~/posts.html#tag for each tag. Clicking on the
link results in a 404 error because posts.html does not exist. This is a very simple
listing of tags that doesn't appear on the navigation bar that fixes the 404 error.
