### PR TITLE
Support relative URL

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -1,7 +1,7 @@
 {% if page.bg %}
-  <aside class="sidebar" role="note" style="background-image: url({{ site.url }}{{ site.images }}/{{ page.bg }})">
+  <aside class="sidebar" role="note" style="background-image: url({{ site.images | relative_url }}/{{ page.bg }})">
 {% else %}
-  <aside class="sidebar" role="note" style="background-image: url({{ site.url }}{{ site.images }}/bg.svg)">
+  <aside class="sidebar" role="note" style="background-image: url({{ site.images | relative_url }}/bg.svg)">
 {% endif %}
 
   <div class="cover">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,14 +20,14 @@ layout: default
 
     <div class="post-links">
       {% if page.next.url %}
-        <a class="link-to-post" href="{{ page.next.url }}">
+        <a class="link-to-post" href="{{ page.next.url | relative_url}}">
           <span class="link-to-post__next">&#10535; &nbsp;Next post</span>
           <span class="link-to-post__title">{{ page.next.title }}</span>
         </a>
       {% endif %}
 
       {% if page.previous.url %}
-        <a class="link-to-post" href="{{ page.previous.url }}">
+        <a class="link-to-post" href="{{ page.previous.url | relative_url}}">
           <span class="link-to-post__prev">&#10535; &nbsp;Previous post</span>
           <span class="link-to-post__title">{{ page.previous.title }}</span>
         </a>

--- a/_posts/2016-06-29-es6.md
+++ b/_posts/2016-06-29-es6.md
@@ -21,7 +21,7 @@ Up & Going: Are you new to programming and JS? This is the roadmap you need to c
 - Types & Grammar
 - Async & Performance
 
-[![railroad]({{ site.images }}/rails.jpg)]({{ site.images }}/rails.jpg)
+[![railroad]({{ site.images | relative_url }}/rails.jpg)]({{ site.images | relative_url }}/rails.jpg)
 
 If you've already read all those titles and you feel pretty comfortable with the topics they cover, it's time we dive into the evolution of JS to explore all the changes coming not only soon but farther over the horizon.
 

--- a/archive.md
+++ b/archive.md
@@ -19,10 +19,10 @@ active: archive
       {% if post.tags contains t %}
         <li>
           {% if post.lastmod %}
-            <a href="{{ post.url }}">{{ post.title }}</a>
+            <a href="{{ post.url | relative_url}}">{{ post.title }}</a>
             <span class="date">{{ post.lastmod | date: "%d-%m-%Y"  }}</span>
           {% else %}
-            <a href="{{ post.url }}">{{ post.title }}</a>
+            <a href="{{ post.url | relative_url}}">{{ post.title }}</a>
             <span class="date">{{ post.date | date: "%d-%m-%Y"  }}</span>
           {% endif %}
         </li>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ summary: "main page"
 
 {% for post in site.posts limit: 5 %}
   <article class="index-page">
-    <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+    <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
     {{ post.excerpt }}
   </article>
 {% endfor %}


### PR DESCRIPTION
Hi redVi

I am interesting your jekyll theme "voyager". But, origin layout setting can't support relative url.

For example, the blog page will occur error page if I use "blog" project and set web site link as 
"https://{username}.github.io/blog/".

Then I try to fix this problem. Now, the web site will run ok even if adding **baseurl** attribute. But, I have another problem, the *images* link in _config.yml file. I can't append base url to pre-link address automatically. So, I need add relative url filter at image link manually ( ex. "{{ site.images | relative_url }}. 

If you have better solution, please let me know. 

Thank you !