### PR TITLE
Add relative link of tag in the aside.html

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -11,7 +11,7 @@
 
         {% if page.tags %}
           {% for tag in page.tags %}
-            <a href="/posts/#{{ tag | downcase }}">{{ tag | downcase }}</a>
+            <a href="{{ site.baseurl }}/posts/#{{ tag | downcase }}">{{ tag | downcase }}</a>
           {% endfor %}
         {% else %}
           {{ page.title }}


### PR DESCRIPTION
Hi redVi

I find an error link in aside.html and update relative path.

Besides, about "image path" config and relative url, the image won't be found if we set **baseurl** and **image path** as "{baseurl}/assets/images" form at the same time. 

For example, the **baseurl** is "/blog" and images path is "/blog/assets/images". The 404 error will be happened because the full path will be "/blog/blog/assets/images/*", the duplicated relative url is occurred.

Because the origin layout uses the **site.images** setting in many positions. Maybe we can notice users this situation and must add relative url filter at markdown linking path.
